### PR TITLE
protectMiddleware should not continue after it redirects

### DIFF
--- a/ginoidc.go
+++ b/ginoidc.go
@@ -154,6 +154,7 @@ func protectMiddleware(config *oauth2.Config) func(c *gin.Context) {
 			log.Fatal("failed save sessions. error: " + err.Error()) // todo handle more gracefully
 		}
 		c.Redirect(http.StatusFound, config.AuthCodeURL(state)) //redirect to authorization server
+		c.Abort()
 	}
 
 }


### PR DESCRIPTION
Without this change, a curl to a REST endpoint returns an a-tag to the redirect along with the data returned by the endpoint.